### PR TITLE
Add age range validation

### DIFF
--- a/server/lib/validationHelpers.ts
+++ b/server/lib/validationHelpers.ts
@@ -24,18 +24,29 @@ export const enhancedCharacterSchema = insertCharacterSchema
     (data) => {
       // La edad es obligatoria solo para tipos específicos
       if (["niño", "niña", "adulto", "adulta"].includes(data.type || "")) {
-        // Verificar si age es un número o string
-        if (typeof data.age === 'number') {
-          return data.age > 0;
-        } else if (typeof data.age === 'string') {
-          return data.age !== null && data.age !== undefined && data.age !== '';
-        }
-        return false;
+        return data.age !== null && data.age !== undefined && data.age !== '';
       }
       return true;
     },
     {
       message: "La edad es obligatoria para personajes de tipo niño/a o adulto",
+      path: ["age"],
+    }
+  )
+  .refine(
+    (data) => {
+      if (["niño", "niña"].includes(data.type || "")) {
+        const ageNumber = typeof data.age === 'number' ? data.age : Number(data.age);
+        return !isNaN(ageNumber) && ageNumber >= 0 && ageNumber <= 18;
+      }
+      if (["adulto", "adulta"].includes(data.type || "")) {
+        const ageNumber = typeof data.age === 'number' ? data.age : Number(data.age);
+        return !isNaN(ageNumber) && ageNumber >= 0 && ageNumber <= 150;
+      }
+      return true;
+    },
+    {
+      message: "La edad debe estar entre 0 y 18 años para niño/a y 0 a 150 para adulto/a",
       path: ["age"],
     }
   );

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,5 @@
-import { pgTable, text, serial, integer, boolean, jsonb, timestamp, date, index } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, boolean, jsonb, timestamp, date, index, check } from "drizzle-orm/pg-core";
+import { sql } from "drizzle-orm";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -51,6 +52,15 @@ export const characters = pgTable(
       userIdIdx: index("characters_user_id_idx").on(table.userId),
       // Índice para buscar personajes por nombre y usuario
       userIdNameIdx: index("characters_user_id_name_idx").on(table.userId, table.name),
+      // Restricción para validar rangos de edad según el tipo de personaje
+      ageRange: check(
+        "characters_age_range_check",
+        sql`(
+          (${table.type} IN ('niño','niña') AND ${table.age} >= 0 AND ${table.age} <= 18) OR
+          (${table.type} IN ('adulto','adulta') AND ${table.age} >= 0 AND ${table.age} <= 150) OR
+          (${table.type} NOT IN ('niño','niña','adulto','adulta'))
+        )`
+      ),
     };
   }
 );


### PR DESCRIPTION
## Summary
- enforce child (0-18) and adult (0-150) age limits in `enhancedCharacterSchema`
- add optional `characters.age` check constraint to the database schema

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6863a306aa88832495ed7713104383ce